### PR TITLE
feat add new group: Functionality to add a new group

### DIFF
--- a/src/components/TabGroup.tsx
+++ b/src/components/TabGroup.tsx
@@ -1,69 +1,139 @@
-import { Box } from "@mui/material";
+import { Box, TextField, Typography } from "@mui/material";
 import { TabGroupProps } from "../types";
 import SavedTab from "./SavedTab";
-import { TabRow } from "../services/supabaseService";
+import { TabRow, updateTabGroup } from "../services/supabaseService";
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 // import { useMemo } from "react";
 import { CSS } from "@dnd-kit/utilities"
+import { purple } from "@mui/material/colors";
+import { useState } from "react";
+import EditIcon from '@mui/icons-material/Edit';
 
 export function TabGroup({ tabGroup, userTabs, userTabsIds, handleDelete }: TabGroupProps) {
 
     const {
         id,
+        name
     } = tabGroup
 
-    // const userTabsIds = useMemo(() => userTabs.map((tab) => tab.id), [userTabs])
-    
-    const {setNodeRef, attributes, listeners,  transform, transition, isDragging} = useSortable(
-        {id: id, 
+    const [tabGroupName, setTabGroupName] = useState<string>(name)
+    const [editMode, setEditMode] = useState(false);
+
+
+    const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable(
+        {
+            id: id,
             data: {
-                type: "tabGroup", 
+                type: "tabGroup",
                 tabGroup
             }
         })
 
-        const style = {
-            transform: CSS.Transform.toString(transform),
-            transition,
-        };
+    const style = {
+        transform: CSS.Transform.toString(transform),
+        transition,
+    };
+
+    const changeTabGroupName = (id: number, name: string) => {
+        updateTabGroup(id, {
+            name: name
+        })
+    }
 
     if (isDragging) {
         return (
             <Box component="div"
-            ref={setNodeRef} //so dnd can handle the div
-            style={style}
-            sx={{bgcolor: 'black',}}
+                ref={setNodeRef} //so dnd can handle the div
+                style={style}
+                sx={{ bgcolor: purple[200], }}
             >
-                
+
             </Box>
         )
     }
 
     return (
-            <Box component="div"
+        <Box
             ref={setNodeRef} //so dnd can handle the div
             style={style}
-            // sx={{bgcolor: 'pink',}}
-            >
-                
-                <Box 
+            sx={{ display: 'flex', flexDirection: 'column', maxWidth: '500px', backgroundColor: '#ffffff', borderRadius: '15px', gap: '8px' }} 
+        >
+
+            <Box
                 {...attributes}
                 {...listeners}
-                >
-                {tabGroup.name}
-                <SortableContext 
-                items={userTabsIds} 
-                strategy={verticalListSortingStrategy}>
-                    {/* equivalent of 'tasks' in tutorial */}
-                {userTabs.map((tab: TabRow) => (
-                    <SavedTab key={tab.id} tab={tab} tabGroupId={id} handleDelete={handleDelete}/>
-                    ))
-                }
-                </SortableContext>
-                </Box>
-                
+                sx={{ gap: '10px' }}
+            >
 
+                <Box sx={{ alignItems: 'center', minWidth: '45%', maxWidth: '100%', display: 'flex', flexDirection: 'row', justifyContent: 'space-between', padding: '12px', backgroundColor: '#ffe0b2', borderRadius: '15px' }}>
+                    {!editMode && (
+                        <>
+                            <Typography>
+                                {tabGroupName}
+                            </Typography>
+
+                            <EditIcon
+                                sx={{
+                                    color: '#f57c00',
+                                    cursor: 'pointer',
+                                    '&:hover': {
+                                        backgroundColor: 'inherit',
+                                        color: '#ff6d00',
+                                    },
+                                    '&:active': {
+                                        backgroundColor: 'inherit',
+                                    },
+                                }}
+                                onClick={() => setEditMode(true)}
+                            />
+                        </>
+                    )}
+                    {editMode && (
+                        <>
+                            <TextField
+                                value={tabGroupName}
+                                onChange={e => setTabGroupName(e.target.value)}
+                                size="small"
+                                autoFocus
+                                onBlur={() => {
+                                    setEditMode(false);
+                                }}
+                                onKeyDown={e => {
+                                    console.log(e.key)
+                                    if (e.key === "Enter") {
+                                        changeTabGroupName(id, tabGroupName)
+                                        setEditMode(false)
+                                    }
+                                }}
+                                sx={{ maxWidth: '200px' }}
+                            />
+                            <EditIcon
+                                sx={{
+                                    color: '#f57c00',
+                                    cursor: 'pointer', 
+                                    '&:hover': {
+                                        backgroundColor: 'inherit',
+                                        color: '#ff6d00',
+                                    },
+                                    '&:active': {
+                                        backgroundColor: '#000000',
+                                    },
+                                }}
+                            />
+                        </>
+                    )}
+                </Box>
             </Box>
+            <SortableContext
+                items={userTabsIds}
+                strategy={verticalListSortingStrategy}>
+                {userTabs.map((tab: TabRow) => (
+                    <SavedTab key={tab.id} tab={tab} tabGroupId={id} handleDelete={handleDelete} />
+                ))
+                }
+            </SortableContext>
+
+        </Box>
 
     )
 }

--- a/src/pages/home/Homepage.tsx
+++ b/src/pages/home/Homepage.tsx
@@ -4,14 +4,15 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { getAllTabGroups, insertTab, TabRow, TabGroupRow, getDefaultTabGroup, insertTabGroup, deleteTabById, getAllTabsSortedByPos, getLatestTabPosition, updateTabPosition } from '../../services/supabaseService';
 import { useAuthContext } from '../../context/AuthProvider';
 import { TabGroup } from '../../components/TabGroup';
-import { closestCorners, DndContext, DragEndEvent, DragOverEvent, DragOverlay, DragStartEvent, KeyboardSensor, PointerSensor, useSensor, useSensors, MouseSensor, TouchSensor } from '@dnd-kit/core';
-import { arrayMove, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
+import { closestCorners, DndContext, DragEndEvent, DragOverEvent, DragOverlay, DragStartEvent, PointerSensor, useSensor, useSensors, MouseSensor, TouchSensor } from '@dnd-kit/core';
+import { arrayMove, SortableContext } from '@dnd-kit/sortable';
 // import { MouseSensor, TouchSensor } from '../../utils/dndCustomSensors';
 import { createPortal } from 'react-dom';
 import SavedTab from '../../components/SavedTab';
 import { NewTab } from '../../types';
-import { Box, Container } from '@mui/material';
+import { Box, Button, Container } from '@mui/material';
 import AccountMenu from '../../components/AccountMenu';
+import AddIcon from '@mui/icons-material/Add';
 
 function Homepage() {
   const userDefaultTabGroup = useRef<number>(0)
@@ -189,6 +190,24 @@ function Homepage() {
     }
   };
 
+  const handleNewTabGroup = async () => {
+    console.log(userTabGroups.length)
+    const newTabGroupNumber = (userTabGroups.length + 1)
+    try {
+      const newTabGroup: TabGroupRow = await insertTabGroup({
+        is_default: false,
+        name: `New Group ${newTabGroupNumber}`,
+        user_id: `${session?.user.id}`
+      });
+      if (newTabGroup) {
+        setUserTabGroups(prevUserTabGroups => [...prevUserTabGroups, newTabGroup])
+      }
+    } catch (error) {
+      console.log(error)
+    }
+    
+  }
+
   const modifyTabData = async (tabData: chrome.tabs.Tab, defaultTabGroup: number, latestTabPos: number) => {
     console.log('modify tab, current default tab group: ', userDefaultTabGroup.current)
     // I should be using a class here 
@@ -263,9 +282,9 @@ function Homepage() {
     }),
     useSensor(MouseSensor),
     useSensor(TouchSensor),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates
-    })
+    // useSensor(KeyboardSensor, {
+    //   coordinateGetter: sortableKeyboardCoordinates
+    // })
   )
 
   function onDragStart(event: DragStartEvent) {
@@ -430,18 +449,19 @@ function Homepage() {
   return (
     <>
     
-    <AccountMenu />
+    
     <Container >
+    <AccountMenu />
     <Box sx={{ maxWidth: '90%'}}>
-    <h1>Up Next</h1>
+    <h1>Tab Pocket</h1>
       <div className="card">
         <button onClick={async () => handleNewTab(await getCurrentTab())}>
-          Add to up next
+          Add to Pocket
         </button>
       </div>
       </Box>
     
-    <Box>
+    <Box sx={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
       <DndContext
         sensors={sensors}
         onDragStart={onDragStart}
@@ -449,7 +469,7 @@ function Homepage() {
         onDragOver={onDragOver}
         collisionDetection={closestCorners}>
           
-        <Box sx={{ flexGrow: 1, maxWidth: '90%', justifyContent: 'center'}}>
+        <Box sx={{display: 'flex', flexDirection: 'column', flexGrow: 1, maxWidth: '90%', justifyContent: 'center', gap: '20px'}}>
           <SortableContext items={userTabGroupsId}>
             {userTabGroups.map((tabGroup: TabGroupRow) => (
               <TabGroup
@@ -488,7 +508,14 @@ function Homepage() {
         )}
         
       </DndContext>
+      <Box sx={{ flexGrow: 1, maxWidth: '90%', justifyContent: 'center'}}>
+        <Button
+        onClick={() => handleNewTabGroup()}
+        ><AddIcon/>'Add New Group'</Button>
       </Box>
+      </Box>
+      
+      
       </Container>
     </>
   )

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -9,6 +9,7 @@ export type TabInsert = Database["public"]["Tables"]["tabs"]["Insert"];
 export type TabUpdate = Database["public"]["Tables"]["tabs"]["Update"];
 export type TabGroupRow = Database["public"]["Tables"]["tab_group"]["Row"];
 export type TabGroupInsert = Database["public"]["Tables"]["tab_group"]["Insert"];
+export type TabGroupUpdate = Database["public"]["Tables"]["tab_group"]["Update"];
 export type TabGroupDefaultInsert = Omit<TabGroupRow, 'id'>;
 export type TabRowLatestPosition = Pick<TabRow, 'position'>
 
@@ -46,6 +47,30 @@ export const insertTabGroup = async (tabGroup: TabGroupInsert): Promise<TabGroup
         // return
     }
     console.log("inserting data:", data);
+    return data;
+};
+
+export const updateTabGroup = async (id: number, tabGroup: TabGroupUpdate): Promise<TabGroupRow> => {
+    const { data, error } = await supabase
+    .from("tab_group")
+    .update(tabGroup)
+    .eq("id", id)
+    .select()
+    .single();
+
+    if (error) {
+        console.error(
+            "Error inserting tab group:",
+            error.message,
+            error.details,
+            error.hint,
+            error.name,
+        );
+        console.error("error data: ", data);
+        throw new Error("Tab group couldn't be updated")
+        // return
+    }
+    console.log("updating data:", data);
     return data;
 };
 
@@ -127,19 +152,7 @@ export const updateTabPosition = async (tab: UpdateTab, id: number ): Promise<Ta
     console.log("inserting data:", data);
     return data;
 };
-
-// Update: {
-//     description?: string | null;
-//     favicon_url?: string | null;
-//     id?: number;
-//     inserted_at?: string;
-//     parsed_url?: string | null;
-//     position?: number;
-//     tab_group_id?: number | null;
-//     updated_at?: string;
-//     url?: string;
-//     user_id?: string;
-// }
+// These should probably be one function - refactor
 
 export const deleteTabById = async (id: number) => {
     const { error } = await supabase.from("tabs").delete().eq("id", id)


### PR DESCRIPTION
* Homepage: Add function to handle creation of a new tab group
* Remove drag-and-drop keyboard sensor, interferes with 'space' button clicks on tab groups and no use case for it atm.
* Some changes to styling to highlight tab groups, change tab group button to a text input.
* TabGroup: add editMode states for editing tab group name.
* TabGroup: Add temporary styling, to be replaced with a theme.